### PR TITLE
do not strip leading and trailing cookie double quotes if allowed

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -358,9 +358,11 @@ func sanitizeCookieName(n string) string {
 // https://tools.ietf.org/html/rfc6265#section-4.1.1
 // cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
 // cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-//           ; US-ASCII characters excluding CTLs,
-//           ; whitespace DQUOTE, comma, semicolon,
-//           ; and backslash
+//
+//	; US-ASCII characters excluding CTLs,
+//	; whitespace DQUOTE, comma, semicolon,
+//	; and backslash
+//
 // We loosen this as spaces and commas are common in cookie Values
 // but we produce a quoted cookie-value if and only if v contains
 // commas or spaces.
@@ -417,8 +419,8 @@ func sanitizeOrWarn(fieldName string, valid func(byte) bool, v string) string {
 }
 
 func parseCookieValue(raw string, allowDoubleQuote bool) (string, bool) {
-	// Strip the quotes, if present.
-	if allowDoubleQuote && len(raw) > 1 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+	// If not allowing double quotes to wrap the cookie value, then strip them
+	if !allowDoubleQuote && len(raw) > 1 && raw[0] == '"' && raw[len(raw)-1] == '"' {
 		raw = raw[1 : len(raw)-1]
 	}
 	for i := 0; i < len(raw); i++ {


### PR DESCRIPTION
**Issue**
Currently, the method `parseCookieValue` method has a bug where the expected logic is inverted.

The bool parameter `allowDoubleQuote` is intended to allow double quotes to wrap a cookies value.

**Example**
cookieName="value"
If the `allowDoubleQuote` is true, the function should apply no change to the value.
If the `allowDoubleQuote` is false, the function should strip the leading and trailing `"` from the cookie value.

This behavior is currently inverted, and is fixed with this simple change.