### PR TITLE
Unzip response only if 'DisableCompression' is off

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -2568,7 +2568,8 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *Response, err err
 	}
 
 	// Set gzip to true if the caller's Accept-Encoding includes gzip.
-	if strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+	if !pc.t.DisableCompression &&
+		strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
 		requestedGzip = true
 	}
 


### PR DESCRIPTION
A fix for the issue: https://github.com/bogdanfinn/tls-client/issues/171
A gzip response shouldn't be unzip'ed if a transport says not to do that using `DisableCompression` option.